### PR TITLE
Reverse proxy configuration for new API path

### DIFF
--- a/apache/ruggedpod-vhost.conf
+++ b/apache/ruggedpod-vhost.conf
@@ -19,6 +19,9 @@
     ErrorLog                 ${APACHE_LOG_DIR}/error.log
     CustomLog                ${APACHE_LOG_DIR}/access.log combined
 
+    ProxyPass                /admin http://localhost/api/v1/
+    ProxyPassReverse         /admin http://localhost/api/v1/
+
     ProxyPass                /serial http://localhost:9000
     ProxyPassReverse         /serial http://localhost:9000
 
@@ -31,6 +34,6 @@
     ProxyPassReverse         /socket.io/ ws://localhost:9000/socket.io/
 
     WSGIDaemonProcess        ruggedpod user=vagrant group=vagrant processes=1 threads=20
-    WSGIScriptAlias          /admin /var/www/ruggedpod.wsgi
+    WSGIScriptAlias          /api /var/www/ruggedpod.wsgi
     WSGIProcessGroup         ruggedpod
 </VirtualHost>


### PR DESCRIPTION
This change is backward compatibile. The legacy patch /admin is routed on the v1 API.

Related to https://github.com/RuggedPOD/ruggedpod-api/pull/14
