### PR TITLE
Fix bug top menubar cannot be click on first load

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -46,6 +46,9 @@ define('ractive', ['Ractive',
             configuration: configurationTpl,
             documentation: documentationTpl,
             serialTerminal: serialTerminalTpl
+        },
+        data: {
+            notification: null
         }
     });
 });


### PR DESCRIPTION
The bar looks like freezed. There's actually an invisible notification on top.

This is a regression introduced in 02ecdd3.
